### PR TITLE
Add support for Extended GTFS Route types (700,800)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Virtual Environment
+venv/

--- a/mzgtfs/route.py
+++ b/mzgtfs/route.py
@@ -82,6 +82,8 @@ class Route(entity.Entity):
       '5': 'cablecar',
       '6': 'gondola',
       '7': 'funicular',
+      '700': 'Bus Service',
+      '800': 'Trolleybus Service',
       None: None,
       '': None
     }[self.get('route_type')]


### PR DESCRIPTION
GTFS has in addition to the usual seven route types an [extended route type](https://support.google.com/transitpartners/answer/3520902?hl=en). This pull request adds support for the route types 700 and 800.

It is necessary in order to add the Berlin (Germany) GTFS feed to transitland.