### PR TITLE
Fix f is not defined in export.py

### DIFF
--- a/mzgtfs/export.py
+++ b/mzgtfs/export.py
@@ -13,7 +13,7 @@ if __name__ == "__main__":
 
   args = parser.parse_args()
   g = feed.Feed(args.filename)
-  f.preload()
+  g.preload()
   print "===== GTFS: %s ====="%g.filename
   for agency in g.agencies():
     print "Agency:", agency['agency_name']


### PR DESCRIPTION
Error message when running export.py

```
File "export.py", line 16, in <module>f.preload()
NameError: name 'f' is not defined
```

Fixed by changing f.preload to g.preload