### PR TITLE
Made feed_info a first class entity

### DIFF
--- a/mzgtfs/entities.py
+++ b/mzgtfs/entities.py
@@ -24,5 +24,4 @@ from farerule import FareRule
 from transfer import Transfer
 from frequency import Frequency
 from fareattribute import FareAttribute
-# from feedinfo import FeedInfo
-FeedInfo = Entity
+from feedinfo import FeedInfo

--- a/mzgtfs/feedinfo.py
+++ b/mzgtfs/feedinfo.py
@@ -1,0 +1,55 @@
+"""GTFS Feed Info entity."""
+import entity
+import geom
+import util
+import validation
+
+class FeedInfo(entity.Entity):
+    """GTFS Feed Info entity."""
+    ENTITY_TYPE = 'o'
+    KEY = 'feed_publisher_name'
+    REQUIRED = [
+        'feed_publisher_name',
+        'feed_publisher_url',
+        'feed_lang'
+    ]
+    OPTIONAL = [
+        'feed_start_date',
+        'feed_end_date',
+        'feed_version',
+        #an OpenTripPlanner construct, not part of the GTFS spec
+        'feed_id'
+    ]
+    def name(self):
+        return self.get('feed_publisher_name')
+
+    def id(self):
+        return self.get('feed_id')
+
+    ##### Validation #####
+
+    def validate(self, validator=None):
+        validator = super(FeedInfo, self).validate(validator)
+        # Required
+        with validator(self):
+            assert self.get('feed_publisher_name'), \
+                "Required: feed_publisher_name"
+
+        with validator(self):
+            assert self.get('feed_publisher_url'), "Required: feed_publisher_url"
+            assert validation.valid_url(self.get('feed_publisher_url')), \
+                "Invalid agency_url"
+
+        with validator(self):
+            assert validation.valid_language(self.get('feed_lang')), \
+            "Invalid language"
+
+        with validator(self):
+            if self.get('feed_start_date'):
+                assert validation.valid_language(self.get('feed_start_date')), \
+                "Invalid start date"
+
+        with validator(self):
+            if self.get('feed_end_date'):
+                assert validation.valid_language(self.get('feed_end_date')), \
+                "Invalid end date"

--- a/mzgtfs/test_feedinfo.py
+++ b/mzgtfs/test_feedinfo.py
@@ -1,0 +1,20 @@
+""" Test Feed Info"""
+import unittest
+import collections
+import entities
+
+class TestFeedInfo(unittest.TestCase):
+  """Test Feed Info."""
+  expect = collections.OrderedDict({
+    'feed_publisher_url': 'http://google.com',
+    'feed_publisher_name': 'Demo Transit Authority',
+    'feed_id': 'DTA',
+  })
+
+  def test_name(self):
+    feed_info = entities.FeedInfo(**self.expect)
+    assert feed_info.name() == self.expect['feed_publisher_name']
+
+  def test_id(self):
+    feed_info = entities.FeedInfo(**self.expect)
+    assert feed_info.id() == self.expect['feed_id']


### PR DESCRIPTION
Currently, the lib treats feed_info as a generic entity. This PR adds it as an actual class with validation.

